### PR TITLE
Adding docker-compose version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,8 @@ For `iconColor` and `iconBG`, use a hexadecimal color or a [Tailwind color](http
 # Docker compose
 
 ```yaml
+version: '3'
+
 services:
     homepage:
         image: jordanroher/starbase-80


### PR DESCRIPTION
There was a docker-compose version missing in the docker-compose example. I added it, picked version 3. Thank you for making this awesome dashboard!