### PR TITLE
Fix conditional rendering

### DIFF
--- a/src/components/header.ts
+++ b/src/components/header.ts
@@ -9,7 +9,10 @@ export const Header = function (props: IProps) {
 	const { icon, title } = props;
 	return `
 		<div class="p-2 xl:p-4 flex flex-nowrap justify-center items-center gap-2 xl:flex-wrap">
-			${!is.null(icon) && `<img src="${icon}" alt="${title || ""}" class="inline-block w-16 h-16" />`}
+			${!is.null(icon) ? 
+				(`<img src="${icon}" alt="${title || ""}" class="inline-block w-16 h-16" />`) :
+				``
+			}
 			<h1>${title}</h1>
 		</div>
 	`;

--- a/src/components/services.ts
+++ b/src/components/services.ts
@@ -30,24 +30,24 @@ function Service(props: IServiceProps) {
 	return `
 		<li class="p-4 flex gap-4">
 			${
-				!is.null(icon) &&
+				!is.null(icon) ?
 				`
 				<span class="flex-shrink-0 flex">
 				${Icon({ name, icon, uri, index, iconColor, iconBG, iconBubble, iconAspect, newWindow })}
 				</span>
-			`
+			` : ``
 			}
 			<div>
 				<h3 class="text-lg mt-1 font-semibold line-clamp-1">
 					${Anchor({ uri, newWindow, children: name })}
 				</h3>
 				${
-					!is.null(description) &&
+					!is.null(description) ?
 					`
 					<p class="text-sm text-black/50 dark:text-white/50 line-clamp-1">
 					${Anchor({ uri, newWindow, children: description })}
 					</p>
-				`
+				` : ``
 				}
 			</div>
 		</li>

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -49,12 +49,12 @@ export const IndexPage = function (props: IProps): string {
 		<div class="min-h-screen">
 			<div class="${pageWrapperClassName}">
 				${
-					SHOWHEADER &&
+					SHOWHEADER ?
 					`
 					<div class="${headerClassName}">
 					${Header({ icon, title })}
 					</div>
-				`
+				` : ``
 				}
 				<div class="${serviceCatalogListWrapperClassName}">
 				${ServiceCatalogList({ catalogs: myServices })}


### PR DESCRIPTION
Hi there,

First of all, thank you for you work! I really like your dashboard :) 

Secondly, while setting up the dashboard for my home server, I found that some optional parameters (such as description, logo, etc) are rendered as `false` instead of not rendered at all. This small PR is intended to fix this

## Some examples: 
When there is the header on the page, I run it with the following envs

```
--env TITLE='Homepage' \
--env LOGO= \
```

When there is no header, I run it with the following envs

```
--env TITLE='Homepage' \
--env HEADER=false \
--env HEADERLINE=false \
```

The config is always the same and is as follows:
```json
[
   {
      "category":"Home",
      "services":[
         {
            "name":"Paperless",
            "uri":"http://docs.local",
            "icon":"/icons/paperless-ngx.jpeg"
         }
      ]
   },
   {
      "category":"Devices",
      "services":[
         {
            "name":"Router",
            "uri":"http://speedport.ip",
            "description":"Speedport Router"
         },
         {
            "name":"Portainer",
            "uri":"https://portainer.local",
            "description":"Portainer",
            "icon":"/icons/portainer.png"
         }
      ]
   }
]
```

### Before

<img width="1440" alt="orig_hdr" src="https://github.com/notclickable-jordan/starbase-80/assets/23486601/4074eb61-d84c-4c26-a5a0-bf39fd90d446">
<img width="1440" alt="orig1" src="https://github.com/notclickable-jordan/starbase-80/assets/23486601/08b1ae4e-16fe-455b-8dc9-489d84b2e28d">

### After

<img width="1440" alt="fork_hdr" src="https://github.com/notclickable-jordan/starbase-80/assets/23486601/aa10fbe5-0181-48e1-857d-cd8c51383f63">
<img width="1440" alt="fork1" src="https://github.com/notclickable-jordan/starbase-80/assets/23486601/efe12ddd-232f-4037-b629-8fcef0ec3e97">

