### PR TITLE
Make whole box clickable #25

### DIFF
--- a/src/components/anchor.ts
+++ b/src/components/anchor.ts
@@ -20,7 +20,7 @@ export const Anchor = function (props: IProps) {
 
 	if (newWindowLocal) {
 		return `
-			<a href="${uri}" target="_blank" rel="noreffer" title="${title || ""}" class="${className || ""}">
+			<a href="${uri}" target="_blank" rel="noreffer" title="${title || ""}" class="${className || "link-box__link"}">
 				${children}
 			</a>
 		`;

--- a/src/components/icon.ts
+++ b/src/components/icon.ts
@@ -1,6 +1,5 @@
 import { is } from "../shared/is";
 import { IconAspect } from "../shared/types";
-import { Anchor } from "./anchor";
 
 const iconColors = [
 	"blue",
@@ -39,27 +38,7 @@ export const Icon = function (props: IProps): string {
 	const { name, uri, icon, index, iconBG, iconBubble, iconColor, iconAspect, newWindow } = props;
 
 	if (is.null(icon)) {
-		if (!is.null(uri)) {
-			return Anchor({ uri: uri as string, title: name, newWindow, children: IconBlank({ index }) });
-		}
-
 		return IconBlank({ index });
-	}
-
-	if (!is.null(uri)) {
-		return Anchor({
-			uri: uri as string,
-			title: name,
-			newWindow,
-			className: "self-center",
-			children: IconBase({
-				icon: icon as string,
-				iconBG,
-				iconColor,
-				iconBubble,
-				iconAspect,
-			}),
-		});
 	}
 
 	return IconBase({

--- a/src/components/services.ts
+++ b/src/components/services.ts
@@ -28,7 +28,7 @@ function Service(props: IServiceProps) {
 	const { name, uri, description, icon, iconBG, iconBubble, iconColor, iconAspect, newWindow } = service;
 
 	return `
-		<li class="p-4 flex gap-4">
+		<li class="link-box p-4 flex gap-4">
 			${
 				!is.null(icon) ?
 				`
@@ -45,7 +45,7 @@ function Service(props: IServiceProps) {
 					!is.null(description) ?
 					`
 					<p class="text-sm text-black/50 dark:text-white/50 line-clamp-1">
-					${Anchor({ uri, newWindow, children: description })}
+					${description}
 					</p>
 				` : ``
 				}

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -36,3 +36,20 @@ h1 {
 	margin: 0;
 	padding: 0;
 }
+
+.link-box {
+    position: relative;
+}
+
+.link-box:hover .link-box__link {
+    text-decoration: underline;
+}
+
+.link-box__link:before {
+    content: "";
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+}


### PR DESCRIPTION
Instead of 3 individual links for logo; title and description, use 1 link for the whole box. It's more accessible for mouse and screenreader users. Also I added a hover effect.