### PR TITLE
Fix non-square icon aspect ratio

### DIFF
--- a/src/components/icon.ts
+++ b/src/components/icon.ts
@@ -96,7 +96,7 @@ function IconBase(props: IIconBaseProps) {
 	}
 
 	// Everyone starts the same size
-	let iconClassName = "block overflow-hidden bg-contain";
+	let iconClassName = "block overflow-hidden bg-contain object-contain";
 	let iconWidthHeightClassName = "";
 
 	switch (iconAspect) {


### PR DESCRIPTION
First off, thanks for your work on this! I tried half a dozen dashboards from awesome-selfhosted and yours really stands out for ease of use and documentation.

This PR prevents non-square icons from stretching to fit the div like the pihole icon here:
<img src="https://github.com/notclickable-jordan/starbase-80/assets/61995646/7627aa46-927b-4458-b14d-051b9781f544" height="350">

Adding `"iconAspect": "height"` to config will prevent this, but it makes the icon div narrower and breaks text alignment:
<img src="https://github.com/notclickable-jordan/starbase-80/assets/61995646/00003618-d693-416c-9c7a-3389ba4ed807" height="350">

Adding the `object-contain` class preserves the icon aspect ratio with no config changes needed (although `iconAspect` can still be used if desired):
<img src="https://github.com/notclickable-jordan/starbase-80/assets/61995646/7d504dc0-a30c-4e7c-b2b4-bb278a238523" height="350">