### PR TITLE
Use docker metadata action so all proper metadata is setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,20 +1,25 @@
 name: docker-ci
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "main"
 
 env:
+  ORIGIN_REPO: notclickable-jordan
   USER: jordanroher
   REPO: starbase-80
 
 jobs:
   build:
+    permissions:
+      contents: write
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set variables
         run: |
@@ -28,18 +33,35 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        if: ${{ github.repository_owner == env.ORIGIN_REPO }}
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          tags: |
+            type=raw,enable=true,value=${{ env.VERSION }}
+            type=raw,enable=true,value=latest
+          images: |
+            name=${{env.USER}}/${{ env.REPO }},enable=${{ github.repository_owner == env.ORIGIN_REPO }}
+            name=ghcr.io/${{ github.repository }}
+
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
-          push: true
           context: .
-          file: dockerfile
+          push: true
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8
-          tags: |
-            ${{ env.USER }}/${{ env.REPO }}:${{ env.VERSION }}
-            ${{ env.USER }}/${{ env.REPO }}:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- Also setup pushing to ghcr to make it easier for forks to test (only builds docker.io release if its on your repo)
- Also update some of the actions

reason for change:
renovate and dependabot like providing notes about changes to images when it can figure out what those changes are. Uses a combo of source/url/revision/etc

The metadata docker action populates all those for you. It even says release notes if you tie it all to releases not commits.

Eg
```
regctl image config --format '{{ jsonPretty .Config.Labels }}' ghcr.io/advplyr/audiobookshelf
{
  "org.opencontainers.image.created": "2025-01-01T22:02:11.840Z",
  "org.opencontainers.image.description": "Self-hosted audiobook and podcast server",
  "org.opencontainers.image.licenses": "GPL-3.0",
  "org.opencontainers.image.revision": "de8b0abc3af740148bddde462fe809f03159d678",
  "org.opencontainers.image.source": "https://github.com/advplyr/audiobookshelf",
  "org.opencontainers.image.title": "audiobookshelf",
  "org.opencontainers.image.url": "https://github.com/advplyr/audiobookshelf",
  "org.opencontainers.image.version": "2.17.7"
}
```

Both renovate and dependabot will gladly parse that data and show changeslogs.

![image](https://github.com/user-attachments/assets/2ad4c544-6f1e-4274-ba2c-568836c4f6d8)
