### PR TITLE
fix(anchor): add noopener noreferrer to anchor

### DIFF
--- a/src/components/anchor.ts
+++ b/src/components/anchor.ts
@@ -20,7 +20,7 @@ export const Anchor = function (props: IProps) {
 
 	if (newWindowLocal) {
 		return `
-			<a href="${uri}" target="_blank" rel="noreffer" title="${title || ""}" class="${className || ""}">
+			<a href="${uri}" target="_blank" rel="noopener noreferrer" title="${title || ""}" class="${className || ""}">
 				${children}
 			</a>
 		`;


### PR DESCRIPTION
The old implementation had an unsupported `rel` attribute which caused some sites to issue a "blocked" message. This commit fixes that issue.