### PR TITLE
Maintain icon aspect ratio (regression fix)

### DIFF
--- a/src/components/icon.ts
+++ b/src/components/icon.ts
@@ -123,7 +123,7 @@ function IconBase(props: IIconBaseProps) {
 	}
 
 	// Everyone starts the same size
-	let bubbleClassName = "flex items-center justify-center overflow-hidden bg-contain object-contain";
+	let bubbleClassName = "flex items-center justify-center overflow-hidden bg-contain";
 	let iconWrapperWidthHeightClassName = "";
 	let iconItselfWidthHeightClassName = "";
 
@@ -146,11 +146,11 @@ function IconBase(props: IIconBaseProps) {
 			break;
 		case "square":
 		default:
-			iconItselfWidthHeightClassName = "w-16 h-16";
+			iconItselfWidthHeightClassName = "w-16 h-16 object-contain";
 			iconWrapperWidthHeightClassName += " w-16 h-16";
 
 			if (iconBubblePadding) {
-				iconItselfWidthHeightClassName = "w-14 h-14";
+				iconItselfWidthHeightClassName = "w-14 h-14 object-contain";
 			}
 			break;
 	}


### PR DESCRIPTION
This fixes a small regression from 59e7adf that caused non-square icons to stretch when `iconAspect` is `square` (default). The first 2 icons here are stretching horizontally, the second 2 vertically:
<img src="https://github.com/user-attachments/assets/1ff543ca-080c-47fc-8834-f7589f87b3f0" height="350">

This happened because `.object-contain` was moved from the icon `img` element to a `span` wrapping it. Moving it back to `img` fixes it:
<img src="https://github.com/user-attachments/assets/a98b020a-5fdd-4249-a8f7-de0f69f10077" height="350">

I tested different combinations of `iconAspect`, `iconBubble`, and `iconBubblePadding` and the stretching only occurred when `iconAspect` is `square`, so I only added `.object-contain` in that switch case block. I also removed it from the span since [object-fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) only applies to [replaced elements](https://developer.mozilla.org/en-US/docs/Glossary/Replaced_elements).